### PR TITLE
Fix Google Sheets API initialization

### DIFF
--- a/fetch_stock_data.py
+++ b/fetch_stock_data.py
@@ -5,7 +5,6 @@ import pandas as pd
 from google.oauth2.service_account import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
-import httplib2
 import logging
 import time
 from curl_cffi import requests
@@ -28,8 +27,7 @@ try:
         creds = Credentials.from_service_account_info(json.loads(os.getenv('GOOGLE_CREDENTIALS')), scopes=SCOPES)
     else:
         raise FileNotFoundError("Google credentials not provided")
-    http = httplib2.Http(timeout=120)
-    service = build('sheets', 'v4', http=http, credentials=creds)
+    service = build('sheets', 'v4', credentials=creds)
 except Exception as e:
     logging.error(f"Failed to initialize Google Sheets API: {str(e)}")
     raise


### PR DESCRIPTION
## Summary
- simplify Google Sheets service setup to avoid mutually-exclusive `http` and `credentials` arguments

## Testing
- `python -m py_compile fetch_stock_data.py`
- `python fetch_stock_data.py` *(fails: FileNotFoundError: Google credentials not provided)*

------
https://chatgpt.com/codex/tasks/task_e_6897103beb0c832fa9f7cfeead6abe60