### PR TITLE
Add S&P 500 EMA10/EMA20 risk-off cash filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Every Saturday, the script:
 1. Looks at all stocks in `tickers.csv`
 2. Checks a momentum signal (MACD)
 3. Keeps only stocks that pass the rule
-4. If too few pass, moves everything to cash
+4. If too few pass, or if S&P 500 EMA10 is below EMA20, moves everything to cash
 5. Otherwise, splits money equally across the passing stocks
 6. Updates performance history, trade log, and dashboard files
 7. Publishes the dashboard through GitHub Pages
@@ -29,6 +29,7 @@ Every Saturday, the script:
   - MACD is above 0
   - MACD is above its signal line (histogram > 0)
 - If **fewer than 10 stocks** qualify, the model goes **100% cash**
+- If **S&P 500 EMA10 is below EMA20**, the model also goes **100% cash**
 
 > This is fully rule-based. No manual stock picking once the list is set.
 


### PR DESCRIPTION
### Motivation
- Enforce an additional risk gate so the strategy moves to cash not only when fewer than `MIN_STOCKS` qualify but also when the S&P 500 short-term trend is weak (EMA10 < EMA20).

### Description
- Added market constants `MARKET_TICKER = "^GSPC"` and EMA spans `MARKET_EMA_FAST = 10`, `MARKET_EMA_SLOW = 20` and implemented `get_market_trend()` to fetch the index and compute EMA10/EMA20 and a `risk_on` flag. (`fetch_stock_data.py`)
- Updated portfolio gating in `run_portfolio()` to accept a `market_trend` parameter and to force full-cash when either `q_count < MIN_STOCKS` or `market_trend['risk_on']` is False, and tag sell reasons with the gate reason(s). (`fetch_stock_data.py`)
- Threaded `market_trend` through `main()` into `run_portfolio()` and `build_html()`, added warning handling when market data is unavailable, and updated dashboard text/banner/footer to explain cash mode due to the market filter. (`fetch_stock_data.py`, `docs/index.html` generation)
- Updated `README.md` to document the new condition that the model also goes to cash when S&P 500 EMA10 is below EMA20. (`README.md`)

### Testing
- Ran Python syntax check: `python -m py_compile fetch_stock_data.py` — success.
- Executed targeted runtime checks invoking `run_portfolio()` in two scenarios via small Python runs: a risk-off market (`market_trend['risk_on']=False`) which confirmed all holdings are exited and sell reason contains `sp500_ema10_below_ema20`; and a risk-on market (`risk_on=True`) with >= MIN_STOCKS qualifying which confirmed new buys proceed as expected — both succeeded.
- Rendered the generated dashboard by starting a local HTTP server and capturing a screenshot of `docs/index.html` to validate the banner and layout — succeeded (screenshot artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a391f51498832faa5a565002eb5df7)